### PR TITLE
feat: [F12MALL-50] [FE] 코인 거래 페이지 실시간 호가창 UI 구현

### DIFF
--- a/FE/trade/css/chart.css
+++ b/FE/trade/css/chart.css
@@ -45,6 +45,7 @@
     font-size: 1.2em;
     font-weight: bold;
     padding-right: 100px; 
+    font-family: 'KIMM_B';
 }
 
 

--- a/FE/trade/css/interface.css
+++ b/FE/trade/css/interface.css
@@ -21,14 +21,14 @@
 
 .box-type-controller > button.active {
   color: #00ff2f;
-  border-top: 0.1rem solid #00ff2f;
-  border-right: 0.1rem solid #00ff2f;
-  border-left: 0.1rem solid #00ff2f;
+  border-top: 0.07rem solid #00ff2f;
+  border-right: 0.07rem solid #00ff2f;
+  border-left: 0.07rem solid #00ff2f;
 }
 
 .box-type-controller > button.deactive {
   color: #ffffff;
-  border-bottom: 0.1rem solid #00ff2f;
+  border-bottom: 0.07rem solid #00ff2f;
   transition: all 0.3s ease;
 }
 
@@ -43,9 +43,9 @@
   flex-direction: column;
   gap: 0.4rem;
   padding: 1rem 1.8rem;
-  border-right: 0.1rem solid #00ff2f;
-  border-bottom: 0.1rem solid #00ff2f;
-  border-left: 0.1rem solid #00ff2f;
+  border-right: 0.07rem solid #00ff2f;
+  border-bottom: 0.07rem solid #00ff2f;
+  border-left: 0.07rem solid #00ff2f;
 }
 
 .box-order-item {
@@ -137,10 +137,22 @@
   font-family: 'KIMM_L';
 }
 
+.box-order-error-message {
+  height: 1rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.box-order-error-message > span {
+  font-size: 0.6rem;
+  color: #f45353;
+  font-family: 'KIMM_L';
+}
+
 .container-interface > div:nth-child(2) .box-order-btn {
   display: flex;
   gap: 1rem;
-  padding-top: 1rem;
 }
 
 .box-order-btn > button {
@@ -178,4 +190,8 @@
 
 .sell-mode .box-order-btn > .order-btn:hover {
   background-color: #0069d9;
+}
+
+.sell-mode .box-fee-info {
+  display: none;
 }

--- a/FE/trade/css/orderbook.css
+++ b/FE/trade/css/orderbook.css
@@ -1,0 +1,110 @@
+.container-orderbook {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.container-orderbook .box-list-controller {
+    display: flex;
+    width: 100%;
+}
+
+.box-list-controller > button {
+    flex: 1;
+    background: none;
+    border: none;
+    padding: 0.7rem;
+    font-size: 1rem;
+    cursor: pointer;
+    font-family: 'KIMM_B';
+}
+
+.box-list-controller > button.active {
+    color: #00ff2f;
+    border-top: 0.07rem solid #00ff2f;
+    border-right: 0.07rem solid #00ff2f;
+    border-left: 0.07rem solid #00ff2f;
+}
+
+.box-list-controller > button.deactive {
+    color: #ffffff;
+    border-bottom: 0.07rem solid #00ff2f;
+    transition: all 0.3s ease;
+}
+
+.box-list-controller > button.deactive:hover {
+    background-color: rgba(0, 255, 47, 0.1);
+    box-shadow: 0 0 0.5rem rgba(0, 255, 47, 0.3);
+    text-shadow: 0 0 0.3rem #00ff2f;
+}
+
+.container-orderbook .box-orderbook-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 1rem 0.6rem;
+    border-right: 0.07rem solid #00ff2f;
+    border-bottom: 0.07rem solid #00ff2f;
+    border-left: 0.07rem solid #00ff2f;
+    flex: 1;
+    width: 100%;
+    overflow-y: auto;
+    scrollbar-width: none;
+}
+
+/* Chrome, Safari, Opera에서 스크롤바 숨기기 */
+.container-orderbook .box-orderbook-content::-webkit-scrollbar {
+    display: none;
+}
+
+.box-orderbook-content .orderbook-row {
+    display: flex;
+    background-color: rgba(62, 62, 62, 0.5);
+    height: 3rem;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-family: 'KIMM_B';
+    padding: 0.4rem 0.5rem;
+}
+
+.orderbook-row .ordered-quantity {
+    flex: 3;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.2rem 0.4rem;
+    color: #ffffff;
+    background-color: rgba(102, 255, 102, 0.25);
+}
+
+.ordered-quantity > span {
+    
+}
+
+.orderbook-row .ordered-price {
+    flex: 2;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.2rem 0.4rem;
+    color: #1376ee;
+}
+
+.ordered-price > span {
+    
+}
+
+.orderbook-row .fluctuation-rate {
+    flex: 2;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 0.2rem 0.4rem;
+    color: #1376ee;
+}
+
+.fluctuation-rate > span {
+    
+}

--- a/FE/trade/css/trade.css
+++ b/FE/trade/css/trade.css
@@ -72,12 +72,10 @@ canvas {
 
 .container-orderbook {
   flex: 5;
-  background-color: rgba(217, 217, 217, 0.36);
 }
 
 /* For visualization */
-.container-chart,
-.container-orderbook {
+.container-chart {
   border: 1px solid #444;
   color: #eee;
   display: flex;

--- a/FE/trade/js/interface.js
+++ b/FE/trade/js/interface.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const totalPriceInput = document.querySelector('.total-price input');
 
   // 수수료 상수
-  const FEE_RATE = 0.05;
+  const FEE_RATE = 1;
 
   // input 값을 가져올 때 빈 값이면 0을 반환하는 함수
   const getInputValue = inputElement => {
@@ -23,7 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const quantity = parseNumberFromString(quantityInput.value);
     const orderPrice = parseNumberFromString(orderPriceInput.value);
 
-    const totalPrice = quantity * orderPrice * (1 + FEE_RATE);
+    const isBuyMode = document.querySelector('.container-interface').classList.contains('buy-mode');
+    const totalPrice = isBuyMode 
+      ? quantity * orderPrice * (1 + FEE_RATE / 100)
+      : quantity * orderPrice;
 
     // 총액을 포맷팅하여 표시
     totalPriceInput.value = totalPrice.toLocaleString('ko-KR');

--- a/FE/trade/js/orderbook.js
+++ b/FE/trade/js/orderbook.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // OrderBook 행 클릭 이벤트 처리
+  const orderBookRows = document.querySelectorAll('.orderbook-row');
+  orderBookRows.forEach(row => {
+    row.addEventListener('click', () => {
+      const price = row.querySelector('.price').textContent;
+      const orderPriceInput = document.querySelector('.order-price input');
+      if (orderPriceInput) {
+        orderPriceInput.value = price;
+        // 가격 입력 후 총액 재계산을 위해 input 이벤트 발생
+        const event = new Event('input', {
+          bubbles: true,
+          cancelable: true,
+        });
+        orderPriceInput.dispatchEvent(event);
+      }
+    });
+  });
+
+  // 가격 포맷팅 함수
+  const formatPrice = (price) => {
+    return parseFloat(price).toLocaleString('ko-KR');
+  };
+
+  // 초기 가격 포맷팅
+  const priceElements = document.querySelectorAll('.orderbook-row .price');
+  priceElements.forEach(element => {
+    element.textContent = formatPrice(element.textContent);
+  });
+}); 

--- a/FE/trade/trade.html
+++ b/FE/trade/trade.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>F12_All-Trade</title>
     <link rel="stylesheet" href="/trade/css/trade.css" />
-    <link rel="stylesheet" href="/trade/css/background.css" />
     <link rel="stylesheet" href="/trade/css/profile.css" />
     <link rel="stylesheet" href="/trade/css/live.css" />
     <link rel="stylesheet" href="/trade/css/chart.css" />
     <link rel="stylesheet" href="/trade/css/interface.css" />
+    <link rel="stylesheet" href="/trade/css/orderbook.css" />
     <link rel="stylesheet" href="/fonts.css" />
     <script src="/trade/js/trade.js"></script>
     <script src="/trade/js/profile.js"></script>
@@ -18,6 +18,7 @@
     <script type="module" src="/hook/ChartAPI.js"></script>
     <script type="module" src="/trade/js/chart.js"></script>
     <script src="/trade/js/interface.js"></script>
+    <script src="/trade/js/orderbook.js"></script>
   </head>
   <body>
     <canvas id="trade-background"></canvas>
@@ -86,7 +87,7 @@
               <div class="box-order-item quantity">
                 <label>주문 수량</label>
                 <div class="input-group">
-                  <input id="order_fis" type="text" placeholder="0" />
+                  <input id="order-fis" type="text" placeholder="0" />
                   <span>FIS</span>
                 </div>
               </div>
@@ -114,7 +115,10 @@
                 </div>
               </div>
               <div class="box-fee-info">
-                <span>수수료 <span id="fee-rate">0.05</span>%</span>
+                <span>수수료 <span id="fee-rate">1</span>%</span>
+              </div>
+              <div class="box-order-error-message">
+                <span>보유 금액이 부족합니다</span>
               </div>
               <div class="box-order-btn">
                 <button class="reset-btn">
@@ -126,7 +130,172 @@
               </div>
             </div>
           </div>
-          <div class="container-orderbook">container-orderbook</div>
+          <div class="container-orderbook myorderlist-mode">
+            <div class="box-list-controller">
+              <button class="orderbook-btn active">
+                <span>OrderBook</span>
+              </button>
+              <button class="myorderlist-btn deactive">
+                <span>MyOrderList</span>
+              </button>
+            </div>
+            <div class="box-orderbook-content">
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>45</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1050</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>+5.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>23</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1040</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>+4.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>67</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1030</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>+3.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>12</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1020</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>+2.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>89</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1010</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>+1.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row current-price">
+                <div class="ordered-quantity">
+                  <span>100</span>
+                </div>
+                <div class="ordered-price">
+                  <span>1000</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>0.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>34</span>
+                </div>
+                <div class="ordered-price">
+                  <span>990</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-1.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>78</span>
+                </div>
+                <div class="ordered-price">
+                  <span>980</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-2.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>56</span>
+                </div>
+                <div class="ordered-price">
+                  <span>970</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-3.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>91</span>
+                </div>
+                <div class="ordered-price">
+                  <span>960</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-4.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>15</span>
+                </div>
+                <div class="ordered-price">
+                  <span>950</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-5.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>10</span>
+                </div>
+                <div class="ordered-price">
+                  <span>940</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-6.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>10</span>
+                </div>
+                <div class="ordered-price">
+                  <span>930</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-7.00</span>%
+                </div>
+              </div>
+              <div class="orderbook-row">
+                <div class="ordered-quantity">
+                  <span>10</span>
+                </div>
+                <div class="ordered-price">
+                  <span>920</span>
+                </div>
+                <div class="fluctuation-rate">
+                  <span>-8.00</span>%
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 작업 개요

- 코인 거래 페이지의 실시간 호가창 UI를 구현했습니다.

## ✅ 작업 상세

- 호가창 UI 구현
- row 수가 많아질 시 스크롤 적용 (스크롤바 숨김)
- 추후 개발될 내용을 고려하여, 주문 인터페이스 내 order-error-message 구역 추가
- 수수료율 1%로 재변경

## 🎫 관련 티켓

- [F12MALL-50](https://dssw5.atlassian.net/browse/F12MALL-50)

## 📎 기타

- 이전에 덮어써진 수수료 0.05% -> 1% 변경 내용 반영했습니다.
- 호가 데이터는 임의의 값과 색상으로 하드코딩했고, 추후 API 연동하며 알맞게 적용될 예정입니다.
<img width="448" alt="image" src="https://github.com/user-attachments/assets/9b9d82bf-734b-464c-a63b-42cae83e829a" />
