### PR TITLE
fix: [F12MALL-111] [BE] 거래 체결 로직 에러 수정

### DIFF
--- a/BE/src/main/java/com/avgmax/trade/domain/Trade.java
+++ b/BE/src/main/java/com/avgmax/trade/domain/Trade.java
@@ -32,14 +32,14 @@ public class Trade extends BaseTimeEntity {
 
     private BigDecimal unitPrice;
 
-    public static Trade of(OrderType requestType, Order buyOrder, Order sellOrder, BigDecimal tradableQuantity) {
+    public static Trade of(OrderType requestType, Order buyOrder, Order sellOrder, BigDecimal tradableQuantity, BigDecimal executedPrice) {
         Order matchedOrder = (requestType == OrderType.BUY) ? sellOrder : buyOrder;
         return Trade.builder()
             .coinId(matchedOrder.getCoinId())
             .buyUserId(buyOrder.getUserId())
             .sellUserId(sellOrder.getUserId())
             .quantity(tradableQuantity)
-            .unitPrice(matchedOrder.getUnitPrice())
+            .unitPrice(executedPrice)
             .build();
     }
 }

--- a/BE/src/main/java/com/avgmax/trade/dto/data/OrderMatchResult.java
+++ b/BE/src/main/java/com/avgmax/trade/dto/data/OrderMatchResult.java
@@ -1,0 +1,13 @@
+package com.avgmax.trade.dto.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+public class OrderMatchResult {
+    private BigDecimal remainingQuantity;
+    private BigDecimal executedAmount;
+} 

--- a/BE/src/main/resources/mapper/trade/OrderMapper.xml
+++ b/BE/src/main/resources/mapper/trade/OrderMapper.xml
@@ -48,7 +48,7 @@
         FROM `ORDER`
         WHERE COIN_ID = #{coinId}
         AND ORDER_TYPE = 'SELL'
-        AND UNIT_PRICE &lt;= #{orderPrice} <!-- 매수 가격 이하의 매도 주문 -->
+        AND UNIT_PRICE &lt;= #{orderPrice} <!-- 매수 가격 이하(<=)의 매도 주문 -->
         ORDER BY UNIT_PRICE DESC, CREATED_AT ASC <!-- 높은 가격부터 낮은 가격 순, 같은 가격은 오래된 순 -->
     </select>
 
@@ -57,7 +57,7 @@
         FROM `ORDER`
         WHERE COIN_ID = #{coinId}
         AND ORDER_TYPE = 'BUY'
-        AND UNIT_PRICE &gt;= #{orderPrice} <!-- 매도 가격 이상의 매수 주문 -->
+        AND UNIT_PRICE &gt;= #{orderPrice} <!-- 매도 가격 이상(>=)의 매수 주문 -->
         ORDER BY UNIT_PRICE ASC, CREATED_AT ASC <!-- 낮은 가격부터 높은 가격 순, 같은 가격은 오래된 순 -->
     </select>
 

--- a/FE/hook/trade/deleteOrder.js
+++ b/FE/hook/trade/deleteOrder.js
@@ -12,6 +12,11 @@ export const cancelOrder = async (coinId, orderId) => {
       throw new Error('주문 취소에 실패했습니다.');
     }
 
+    // 204 No Content 또는 응답 본문이 없는 경우 처리
+    if (response.status === 204) {
+      return null;
+    }
+
     return await response.json();
   } catch (error) {
     console.error('주문 취소 API 호출 중 오류 발생:', error);

--- a/FE/trade/css/orderbook.css
+++ b/FE/trade/css/orderbook.css
@@ -93,7 +93,7 @@
     top: 0;
     right: 0;
     height: 100%;
-    opacity: 0.6;
+    opacity: 0.5;
 }
 
 .quantity-wrapper .quantity-text {

--- a/FE/trade/trade.html
+++ b/FE/trade/trade.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>F12_All-Trade</title>
+    <link rel="icon" href="/favicon.png" />
     <link rel="stylesheet" href="/trade/css/trade.css" />
     <link rel="stylesheet" href="/trade/css/profile.css" />
     <link rel="stylesheet" href="/trade/css/live.css" />


### PR DESCRIPTION
## 📌 작업 개요

- 거래 체결 로직의 에러를 수정했습니다.

## ✅ 작업 상세

- 주문 요청 시 체결 로직을 갈아 엎어서 정상적으로 money와 usercoin이 차감 및 획득되도록 수정했습니다.
- 주문 요청 시, 보유 자산 및 내 주문 목록이 바로 업데이트되도록 수정했습니다.
- 주문 취소 API를 연동했습니다.
- 주문 취소 시, 보유 자산도 업데이트되도록 수정했습니다.

## 🎫 관련 티켓

- [F12MALL-111](https://dssw5.atlassian.net/browse/F12MALL-111)

## 📎 기타

- 리뷰어가 참고해야 할 내용이 있다면 기재합니다.